### PR TITLE
add 'Params' field to Repo struct

### DIFF
--- a/drone/repos.go
+++ b/drone/repos.go
@@ -9,6 +9,7 @@ type RepoService struct {
 }
 
 // GET /api/repos/{host}/{owner}/{name}
+// This query will return privileged attributes only if the token used has admin privileges.
 func (s *RepoService) Get(host, owner, name string) (*Repo, error) {
 	var path = fmt.Sprintf("/api/repos/%s/%s/%s", host, owner, name)
 	var repo = Repo{}
@@ -62,6 +63,7 @@ func (s *RepoService) SetParams(host, owner, name, params string) error {
 }
 
 // GET /api/user/repos
+// This query does not return privileged attributes.
 func (s *RepoService) List() ([]*Repo, error) {
 	var repos []*Repo
 	var err = s.run("GET", "/api/user/repos", nil, &repos)

--- a/drone/types.go
+++ b/drone/types.go
@@ -28,11 +28,13 @@ type Repo struct {
 	Privileged  bool   `json:"privileged"`
 	PostCommit  bool   `json:"post_commits"`
 	PullRequest bool   `json:"pull_requests"`
-	PublicKey   string `json:"public_key"`
 	PrivateKey  string `json:"private_key"`
 	Timeout     int64  `json:"timeout"`
 	Created     int64  `json:"created_at"`
 	Updated     int64  `json:"updated_at"`
+	// NOTE: these fields will be blank unless the token used has admin privileges
+	Params    string `json:"params"`
+	PublicKey string `json:"public_key"`
 }
 
 type Commit struct {


### PR DESCRIPTION
The field is added to the returned struct here: https://github.com/drone/drone/blob/master/server/handler/repo.go#L43-L44