### PR TITLE
Updating Render to take a drone.Payload instead of an empty interface

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -16,32 +16,25 @@ func init() {
 	raymond.RegisterHelpers(funcs)
 }
 
-type Args struct {
-	Repo   *drone.Repo   `json:"repo"`
-	Build  *drone.Build  `json:"build"`
-	System *drone.System `json:"system"`
-	Vargs  interface{}   `json:"vargs"`
-}
-
 // Render parses and executes a template, returning the results
 // in string format.
-func Render(template string, args interface{}) (string, error) {
-	return raymond.Render(template, normalize(args))
+func Render(template string, playload *drone.Payload) (string, error) {
+	return raymond.Render(template, normalize(playload))
 }
 
 // RenderTrim parses and executes a template, returning the results
 // in string format. The result is trimmed to remove left and right
 // padding and newlines that may be added unintentially in the
 // template markup.
-func RenderTrim(template string, args interface{}) (string, error) {
-	out, err := Render(template, args)
+func RenderTrim(template string, playload *drone.Payload) (string, error) {
+	out, err := Render(template, playload)
 	return strings.Trim(out, " \n"), err
 }
 
 // Write parses and executes a template, writing the results to
 // writer w.
-func Write(w io.Writer, template string, args interface{}) error {
-	out, err := Render(template, args)
+func Write(w io.Writer, template string, playload *drone.Payload) error {
+	out, err := Render(template, playload)
 	if err != nil {
 		return err
 	}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -7,70 +7,73 @@ import (
 )
 
 var tests = []struct {
-	Build  drone.Build
-	Input  string
-	Output string
+	Payload *drone.Payload
+	Input   string
+	Output  string
 }{
 	{
-		drone.Build{Number: 1},
-		"build #{{number}}",
+		&drone.Payload{Build: &drone.Build{Number: 1}},
+		"build #{{build.number}}",
 		"build #1",
 	},
 	{
-		drone.Build{Status: drone.StatusSuccess},
-		"{{uppercase status}}",
+		&drone.Payload{Build: &drone.Build{Status: drone.StatusSuccess}},
+		"{{uppercase build.status}}",
 		"SUCCESS",
 	},
 	{
-		drone.Build{Author: "Octocat"},
-		"{{lowercase author}}",
+		&drone.Payload{Build: &drone.Build{Author: "Octocat"}},
+		"{{lowercase build.author}}",
 		"octocat",
 	},
 	{
-		drone.Build{Status: drone.StatusSuccess},
-		"{{uppercasefirst status}}",
+		&drone.Payload{Build: &drone.Build{Status: drone.StatusSuccess}},
+		"{{uppercasefirst build.status}}",
 		"Success",
 	},
 	{
-		drone.Build{Started: 1448127131, Finished: 1448127505},
-		"{{ duration started_at finished_at }}",
+		&drone.Payload{Build: &drone.Build{
+			Started:  1448127131,
+			Finished: 1448127505},
+		},
+		"{{ duration build.started_at build.finished_at }}",
 		"374ns",
 	},
 	{
-		drone.Build{Finished: 1448127505},
-		`finished at {{ datetime finished_at "3:04PM" "UTC" }}`,
+		&drone.Payload{Build: &drone.Build{Finished: 1448127505}},
+		`finished at {{ datetime build.finished_at "3:04PM" "UTC" }}`,
 		"finished at 5:38PM",
 	},
 	// verify the success if / else block works
 	{
-		drone.Build{Status: drone.StatusSuccess},
-		"{{#success status}}SUCCESS{{/success}}",
+		&drone.Payload{Build: &drone.Build{Status: drone.StatusSuccess}},
+		"{{#success build.status}}SUCCESS{{/success}}",
 		"SUCCESS",
 	},
 	{
-		drone.Build{Status: drone.StatusFailure},
-		"{{#success status}}SUCCESS{{/success}}",
+		&drone.Payload{Build: &drone.Build{Status: drone.StatusFailure}},
+		"{{#success build.status}}SUCCESS{{/success}}",
 		"",
 	},
 	{
-		drone.Build{Status: drone.StatusFailure},
-		"{{#success status}}SUCCESS{{else}}NOT SUCCESS{{/success}}",
+		&drone.Payload{Build: &drone.Build{Status: drone.StatusFailure}},
+		"{{#success build.status}}SUCCESS{{else}}NOT SUCCESS{{/success}}",
 		"NOT SUCCESS",
 	},
 	// verify the failure if / else block works
 	{
-		drone.Build{Status: drone.StatusFailure},
-		"{{#failure status}}FAILURE{{/failure}}",
+		&drone.Payload{Build: &drone.Build{Status: drone.StatusFailure}},
+		"{{#failure build.status}}FAILURE{{/failure}}",
 		"FAILURE",
 	},
 	{
-		drone.Build{Status: drone.StatusSuccess},
-		"{{#failure status}}FAILURE{{/failure}}",
+		&drone.Payload{Build: &drone.Build{Status: drone.StatusSuccess}},
+		"{{#failure build.status}}FAILURE{{/failure}}",
 		"",
 	},
 	{
-		drone.Build{Status: drone.StatusSuccess},
-		"{{#failure status}}FAILURE{{else}}NOT FAILURE{{/failure}}",
+		&drone.Payload{Build: &drone.Build{Status: drone.StatusSuccess}},
+		"{{#failure build.status}}FAILURE{{else}}NOT FAILURE{{/failure}}",
 		"NOT FAILURE",
 	},
 }
@@ -78,7 +81,7 @@ var tests = []struct {
 func TestTemplate(t *testing.T) {
 
 	for _, test := range tests {
-		got, err := RenderTrim(test.Input, &test.Build)
+		got, err := RenderTrim(test.Input, test.Payload)
 		if err != nil {
 			t.Errorf("Failed rendering template %q, got error %s.", test.Input, err)
 		}


### PR DESCRIPTION
This PR updates the render and write methods in the `template` package to take a `drone.Payload` struct instead of an empty `interface{}`. 