### PR TITLE
Adding truncate func helper and unit test

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -51,11 +51,11 @@ var funcs = map[string]interface{}{
 	"datetime":       toDatetime,
 	"success":        isSuccess,
 	"failure":        isFailure,
-	"limit":          limit,
+	"truncate":       truncate,
 }
 
-// limit is a helper function that truncates a string by a particular length.
-func limit(s string, len int) string {
+// truncate is a helper function that truncates a string by a particular length.
+func truncate(s string, len int) string {
 	if utf8.RuneCountInString(s) <= len {
 		return s
 	}

--- a/template/template.go
+++ b/template/template.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/aymerick/raymond"
 	"github.com/drone/drone-go/drone"
@@ -43,13 +44,24 @@ func Write(w io.Writer, template string, playload *drone.Payload) error {
 }
 
 var funcs = map[string]interface{}{
+	"uppercasefirst": uppercaseFirst,
 	"uppercase":      strings.ToUpper,
 	"lowercase":      strings.ToLower,
-	"uppercasefirst": uppercaseFirst,
 	"duration":       toDuration,
 	"datetime":       toDatetime,
 	"success":        isSuccess,
 	"failure":        isFailure,
+	"limit":          limit,
+}
+
+// limit is a helper function that truncates a string by a particular length.
+func limit(s string, len int) string {
+	if utf8.RuneCountInString(s) <= len {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:len])
+
 }
 
 // uppercaseFirst is a helper function that takes a string and capitalizes

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -15,7 +15,7 @@ var tests = []struct {
 		&drone.Payload{Build: &drone.Build{
 			Commit: "0a266f42a9aef9db97a005ab46f6c53890339a9c"},
 		},
-		"{{ limit build.commit 8 }}",
+		"{{ truncate build.commit 8 }}",
 		"0a266f42",
 	},
 	{

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -12,6 +12,13 @@ var tests = []struct {
 	Output  string
 }{
 	{
+		&drone.Payload{Build: &drone.Build{
+			Commit: "0a266f42a9aef9db97a005ab46f6c53890339a9c"},
+		},
+		"{{ limit build.commit 8 }}",
+		"0a266f42",
+	},
+	{
 		&drone.Payload{Build: &drone.Build{Number: 1}},
 		"build #{{build.number}}",
 		"build #1",


### PR DESCRIPTION
This pull request adds `truncate ` as a helper function for the `template` package.  This allows for templates like `{{ repo.owner }}/{{ repo.name }}#{{ truncate build.commit 8 }}` to be rendered.