### PR TITLE
Updating the duration helper function in the template package

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -76,8 +76,7 @@ func uppercaseFirst(s string) string {
 // toDuration is a helper function that calculates a duration for a start and
 // and end time, and returns the duration in string format.
 func toDuration(started, finished float64) string {
-	dur := time.Duration(int64(finished - started))
-	return fmt.Sprintln(dur)
+	return fmt.Sprintln(time.Duration(finished-started) * time.Second)
 }
 
 // toDatetime is a helper function that converts a unix timestamp to a string.

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -44,7 +44,7 @@ var tests = []struct {
 			Finished: 1448127505},
 		},
 		"{{ duration build.started_at build.finished_at }}",
-		"374ns",
+		"6m14s",
 	},
 	{
 		&drone.Payload{Build: &drone.Build{Finished: 1448127505}},


### PR DESCRIPTION
This will make the `duration` helper report time back in terms of seconds and minutes.  So instead of reporting back `374ns`, it will report back `6m14s`.