### PR TITLE
Add intermediate netrc struct and custom JSON marshaling methods to Netrc

### DIFF
--- a/drone/netrc_test.go
+++ b/drone/netrc_test.go
@@ -1,0 +1,64 @@
+package drone
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNetrcMarshaling(t *testing.T) {
+	var tests = []struct {
+		num    int
+		input  string
+		output string
+	}{
+		{
+			1,
+			`{"machine": "Apple 2", "login": "MeMyselfAndI", "password": "pass123"}`,
+			`{"machine":"Apple 2","login":"MeMyselfAndI","password":"pass123","user":"pass123"}`,
+		},
+		{
+			2,
+			`{"machine": "Apple 2", "login": "MeMyselfAndI", "user": "pass123"}`,
+			`{"machine":"Apple 2","login":"MeMyselfAndI","password":"pass123","user":"pass123"}`,
+		},
+		{
+			3,
+			`{"machine": "Apple 2", "login": "MeMyselfAndI"}`,
+			`{"machine":"Apple 2","login":"MeMyselfAndI","password":"","user":""}`,
+		},
+		{
+			4,
+			`{"machine": "Apple 2", "password": "pass123"}`,
+			`{"machine":"Apple 2","login":"","password":"pass123","user":"pass123"}`,
+		},
+		{
+			5,
+			`{"machine": "Apple 2", "user": "pass123"}`,
+			`{"machine":"Apple 2","login":"","password":"pass123","user":"pass123"}`,
+		},
+		{
+			6,
+			`{ "login": "MeMyselfAndI", "password": "pass123"}`,
+			`{"machine":"","login":"MeMyselfAndI","password":"pass123","user":"pass123"}`,
+		},
+		{
+			7,
+			`{ "login": "MeMyselfAndI", "user": "pass123"}`,
+			`{"machine":"","login":"MeMyselfAndI","password":"pass123","user":"pass123"}`,
+		},
+	}
+
+	for _, test := range tests {
+		var netrc = Netrc{}
+		if err := json.Unmarshal([]byte(test.input), &netrc); err != nil {
+			panic(err)
+		}
+		bytes, err := json.Marshal(netrc)
+		if err != nil {
+			panic(err)
+		}
+		if string(bytes) != test.output {
+			t.Errorf("test %d expected %q got %q", test.num, test.output, string(bytes))
+		}
+	}
+}

--- a/drone/types.go
+++ b/drone/types.go
@@ -1,5 +1,7 @@
 package drone
 
+import "encoding/json"
+
 // User represents a user account.
 type User struct {
 	ID     int64  `json:"id"`
@@ -121,7 +123,45 @@ type Key struct {
 type Netrc struct {
 	Machine  string `json:"machine"`
 	Login    string `json:"login"`
-	Password string `json:"user"`
+	Password string `json:"password"`
+}
+
+// netrc is only used to allow compatibility with older plugins that rely on
+// the JSON "user" attribute as a password value. In Drone 0.6 breaking
+// changes will be introduced and this netrc struct and the Netrc UnmarshalJSON
+// and MarshalJSON will be removed.
+type netrc struct {
+	Machine     string `json:"machine"`
+	Login       string `json:"login"`
+	Password    string `json:"password"`
+	PasswordOld string `json:"user"`
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (n *Netrc) UnmarshalJSON(b []byte) error {
+	x := &netrc{}
+	err := json.Unmarshal(b, x)
+	if err != nil {
+		return err
+	}
+	n.Machine = x.Machine
+	n.Login = x.Login
+	n.Password = x.Password
+	if x.PasswordOld != "" {
+		n.Password = x.PasswordOld
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (n Netrc) MarshalJSON() ([]byte, error) {
+	x := &netrc{
+		Machine:     n.Machine,
+		Login:       n.Login,
+		Password:    n.Password,
+		PasswordOld: n.Password,
+	}
+	return json.Marshal(x)
 }
 
 // System represents the drone system.


### PR DESCRIPTION
This PR attempts to fix a bug with the `Netrc` JSON struct tag being named `"user"` instead of `"password"` while maintaining compatibility with current plugins that rely on the `"user"` syntax.

You can find the problematic line here: https://github.com/drone/drone-go/blob/master/drone/types.go#L124

More information about `.netrc` the file format here: https://www-01.ibm.com/support/knowledgecenter/ssw_aix_71/com.ibm.aix.files/netrc.htm