### PR TITLE
Removing a line about 'plugin' that does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Download the package using `go get`:
 
 ```Go
 go get "github.com/drone/drone-go/drone"
-go get "github.com/drone/drone-go/plugin"
 ```
 
 Import the package:


### PR DESCRIPTION
The 'plugin' folder was removed in the commit 81791520a911938028603d7911bf65107a17ffea