### PR TITLE
Drone log purge

### DIFF
--- a/drone/client.go
+++ b/drone/client.go
@@ -27,6 +27,7 @@ const (
 	pathDecline        = "%s/api/repos/%s/%s/builds/%d/decline"
 	pathJob            = "%s/api/repos/%s/%s/builds/%d/%d"
 	pathLog            = "%s/api/repos/%s/%s/logs/%d/%d"
+	pathLogPurge       = "%s/api/repos/%s/%s/logs/%d"
 	pathRepoSecrets    = "%s/api/repos/%s/%s/secrets"
 	pathRepoSecret     = "%s/api/repos/%s/%s/secrets/%s"
 	pathRepoRegistries = "%s/api/repos/%s/%s/registry"

--- a/drone/client.go
+++ b/drone/client.go
@@ -310,6 +310,13 @@ func (c *client) Deploy(owner, name string, num int, env string, params map[stri
 	return out, err
 }
 
+// LogsPurge purges the build logs for the specified build.
+func (c *client) LogsPurge(owner, name string, num int) error {
+	uri := fmt.Sprintf(pathLogPurge, c.addr, owner, name, num)
+	err := c.delete(uri)
+	return err
+}
+
 // Registry returns a registry by hostname.
 func (c *client) Registry(owner, name, hostname string) (*Registry, error) {
 	out := new(Registry)

--- a/drone/interface.go
+++ b/drone/interface.go
@@ -86,6 +86,9 @@ type Client interface {
 	// target environment.
 	Deploy(string, string, int, string, map[string]string) (*Build, error)
 
+	// LogsPurge purges the build logs for the specified build.
+	LogsPurge(string, string, int) error
+
 	// Registry returns a registry by hostname.
 	Registry(owner, name, hostname string) (*Registry, error)
 


### PR DESCRIPTION
Client library function to call the log purge endpoint.

https://github.com/drone/drone/blob/9e68a09f50723292d58ffb5bb10cd694ca1688ac/router/router.go#L120

Required for CLI updates.