### PR TITLE
Support params on BuildList

### DIFF
--- a/drone/client.go
+++ b/drone/client.go
@@ -245,7 +245,10 @@ func (c *client) BuildLast(owner, name, branch string) (*Build, error) {
 // the specified repository.
 func (c *client) BuildList(owner, name string, params *ListParams) ([]*Build, error) {
 	var out []*Build
-	val := params.URLValues()
+	val := url.Values{}
+	if params != nil {
+		val = params.URLValues()
+	}
 	uri := fmt.Sprintf(pathBuilds, c.addr, owner, name)
 	err := c.get(uri+"?"+val.Encode(), &out)
 	return out, err

--- a/drone/client.go
+++ b/drone/client.go
@@ -243,9 +243,9 @@ func (c *client) BuildLast(owner, name, branch string) (*Build, error) {
 
 // BuildList returns a list of recent builds for the
 // the specified repository.
-func (c *client) BuildList(owner, name string, params map[string]string) ([]*Build, error) {
+func (c *client) BuildList(owner, name string, params *ListParams) ([]*Build, error) {
 	var out []*Build
-	val := mapValues(params)
+	val := params.URLValues()
 	uri := fmt.Sprintf(pathBuilds, c.addr, owner, name)
 	err := c.get(uri+"?"+val.Encode(), &out)
 	return out, err

--- a/drone/client.go
+++ b/drone/client.go
@@ -243,10 +243,11 @@ func (c *client) BuildLast(owner, name, branch string) (*Build, error) {
 
 // BuildList returns a list of recent builds for the
 // the specified repository.
-func (c *client) BuildList(owner, name string) ([]*Build, error) {
+func (c *client) BuildList(owner, name string, params map[string]string) ([]*Build, error) {
 	var out []*Build
+	val := mapValues(params)
 	uri := fmt.Sprintf(pathBuilds, c.addr, owner, name)
-	err := c.get(uri, &out)
+	err := c.get(uri+"?"+val.Encode(), &out)
 	return out, err
 }
 

--- a/drone/interface.go
+++ b/drone/interface.go
@@ -62,7 +62,7 @@ type Client interface {
 
 	// BuildList returns a list of recent builds for the
 	// the specified repository.
-	BuildList(string, string) ([]*Build, error)
+	BuildList(string, string, *ListParams) ([]*Build, error)
 
 	// BuildQueue returns a list of enqueued builds.
 	BuildQueue() ([]*Activity, error)

--- a/drone/types.go
+++ b/drone/types.go
@@ -1,5 +1,10 @@
 package drone
 
+import (
+	"net/url"
+	"strconv"
+)
+
 type (
 	// User represents a user account.
 	User struct {
@@ -169,4 +174,16 @@ type (
 		Version string `json:"version,omitempty"`
 		Commit  string `json:"commit,omitempty"`
 	}
+
+	ListParams struct {
+		Page  int
+		Limit int
+	}
 )
+
+func (lp *ListParams) URLValues() url.Values {
+	return url.Values{
+		"page":  []string{strconv.Itoa(lp.Page)},
+		"limit": []string{strconv.Itoa(lp.Limit)},
+	}
+}

--- a/drone/types.go
+++ b/drone/types.go
@@ -181,6 +181,13 @@ type (
 	}
 )
 
+func NewListParams() *ListParams {
+	return &ListParams{
+		Page:  1,
+		Limit: 50,
+	}
+}
+
 func (lp *ListParams) URLValues() url.Values {
 	return url.Values{
 		"page":  []string{strconv.Itoa(lp.Page)},


### PR DESCRIPTION
GetBuilds was updated to support pagination on the server side (https://github.com/drone/drone/commit/c84031e3e8491aad184acb2f2c8a9168831d1f34#diff-3e2b3bf62043203836f33865c241e4f0), but no such support exists for this client. This adds support for generic params to be somewhat future proof against future query param additions.