### PR TITLE
Change `RepoPatch.Counter` type to `int64` from `int`

### DIFF
--- a/drone/types.go
+++ b/drone/types.go
@@ -85,7 +85,7 @@ type (
 		IgnorePulls *bool   `json:"ignore_pull_requests"`
 		CancelPulls *bool   `json:"auto_cancel_pull_requests"`
 		CancelPush  *bool   `json:"auto_cancel_pushes"`
-		Counter     *int    `json:"counter,omitempty"`
+		Counter     *int64  `json:"counter,omitempty"`
 	}
 
 	// Build defines a build object.


### PR DESCRIPTION
`Repo.Counter` type and `counter` type of patch api handler is `int64`:

https://github.com/drone/drone-go/blob/5af8148e75b6990769cc7051926b908ec2512eac/drone/types.go#L44-L67

https://github.com/drone/drone/blob/0b4e5156ae1111463145e522e206eacb6d036960/handler/api/repos/update.go#L30-L40

Bad, `RepoPatch.Counter` type is `int`.
I think better that these types will be same.