### PR TITLE
Use the ctx provided when invoking a plugin

### DIFF
--- a/plugin/admission/client.go
+++ b/plugin/admission/client.go
@@ -36,6 +36,6 @@ type pluginClient struct {
 
 func (c *pluginClient) Admit(ctx context.Context, in *Request) (*drone.User, error) {
 	res := new(drone.User)
-	err := c.client.Do(in, res)
+	err := c.client.DoUsingContext(ctx, in, res)
 	return res, err
 }

--- a/plugin/admission/client.go
+++ b/plugin/admission/client.go
@@ -36,6 +36,6 @@ type pluginClient struct {
 
 func (c *pluginClient) Admit(ctx context.Context, in *Request) (*drone.User, error) {
 	res := new(drone.User)
-	err := c.client.DoUsingContext(ctx, in, res)
+	err := c.client.Do(ctx, in, res)
 	return res, err
 }

--- a/plugin/config/client.go
+++ b/plugin/config/client.go
@@ -36,6 +36,6 @@ type pluginClient struct {
 
 func (c *pluginClient) Find(ctx context.Context, in *Request) (*drone.Config, error) {
 	res := new(drone.Config)
-	err := c.client.Do(in, res)
+	err := c.client.DoUsingContext(ctx, in, res)
 	return res, err
 }

--- a/plugin/config/client.go
+++ b/plugin/config/client.go
@@ -36,6 +36,6 @@ type pluginClient struct {
 
 func (c *pluginClient) Find(ctx context.Context, in *Request) (*drone.Config, error) {
 	res := new(drone.Config)
-	err := c.client.DoUsingContext(ctx, in, res)
+	err := c.client.Do(ctx, in, res)
 	return res, err
 }

--- a/plugin/converter/client.go
+++ b/plugin/converter/client.go
@@ -36,6 +36,6 @@ type pluginClient struct {
 
 func (c *pluginClient) Convert(ctx context.Context, in *Request) (*drone.Config, error) {
 	res := new(drone.Config)
-	err := c.client.Do(in, res)
+	err := c.client.DoUsingContext(ctx, in, res)
 	return res, err
 }

--- a/plugin/converter/client.go
+++ b/plugin/converter/client.go
@@ -36,6 +36,6 @@ type pluginClient struct {
 
 func (c *pluginClient) Convert(ctx context.Context, in *Request) (*drone.Config, error) {
 	res := new(drone.Config)
-	err := c.client.DoUsingContext(ctx, in, res)
+	err := c.client.Do(ctx, in, res)
 	return res, err
 }

--- a/plugin/environ/client.go
+++ b/plugin/environ/client.go
@@ -35,6 +35,6 @@ type pluginClient struct {
 
 func (c *pluginClient) List(ctx context.Context, in *Request) ([]*Variable, error) {
 	res := []*Variable{}
-	err := c.client.Do(in, &res)
+	err := c.client.DoUsingContext(ctx, in, &res)
 	return res, err
 }

--- a/plugin/environ/client.go
+++ b/plugin/environ/client.go
@@ -35,6 +35,6 @@ type pluginClient struct {
 
 func (c *pluginClient) List(ctx context.Context, in *Request) ([]*Variable, error) {
 	res := []*Variable{}
-	err := c.client.DoUsingContext(ctx, in, &res)
+	err := c.client.Do(ctx, in, &res)
 	return res, err
 }

--- a/plugin/internal/client/client.go
+++ b/plugin/internal/client/client.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/drone/drone-go/plugin/internal/aesgcm"
 
-	"github.com/99designs/httpsignatures-go"
+	httpsignatures "github.com/99designs/httpsignatures-go"
 )
 
 // DefaultClient is the default http.Client.
@@ -90,12 +90,8 @@ type Client struct {
 	SkipVerify bool
 }
 
-// Do makes an http.Request to the target endpoint.
-func (s *Client) Do(in, out interface{}) error {
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
+// DoUsingContext makes an http.Request to the target endpoint using the context provided.
+func (s *Client) DoUsingContext(ctx context.Context, in, out interface{}) error {
 	data, err := json.Marshal(in)
 	if err != nil {
 		return err
@@ -177,6 +173,15 @@ func (s *Client) Do(in, out interface{}) error {
 		return nil
 	}
 	return json.Unmarshal(body, out)
+}
+
+// Do makes an http.Request to the target endpoint using a context with a one minute timeout.
+func (s *Client) Do(in, out interface{}) error {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	return s.DoUsingContext(ctx, in, out)
 }
 
 func (s *Client) client() *http.Client {

--- a/plugin/internal/client/client.go
+++ b/plugin/internal/client/client.go
@@ -90,8 +90,8 @@ type Client struct {
 	SkipVerify bool
 }
 
-// DoUsingContext makes an http.Request to the target endpoint using the context provided.
-func (s *Client) DoUsingContext(ctx context.Context, in, out interface{}) error {
+// Do makes an http.Request to the target endpoint using the context provided.
+func (s *Client) Do(ctx context.Context, in, out interface{}) error {
 	data, err := json.Marshal(in)
 	if err != nil {
 		return err
@@ -173,15 +173,6 @@ func (s *Client) DoUsingContext(ctx context.Context, in, out interface{}) error 
 		return nil
 	}
 	return json.Unmarshal(body, out)
-}
-
-// Do makes an http.Request to the target endpoint using a context with a one minute timeout.
-func (s *Client) Do(in, out interface{}) error {
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	return s.DoUsingContext(ctx, in, out)
 }
 
 func (s *Client) client() *http.Client {

--- a/plugin/registry/client.go
+++ b/plugin/registry/client.go
@@ -36,6 +36,6 @@ type pluginClient struct {
 
 func (c *pluginClient) List(ctx context.Context, in *Request) ([]*drone.Registry, error) {
 	res := []*drone.Registry{}
-	err := c.client.DoUsingContext(ctx, in, &res)
+	err := c.client.Do(ctx, in, &res)
 	return res, err
 }

--- a/plugin/registry/client.go
+++ b/plugin/registry/client.go
@@ -36,6 +36,6 @@ type pluginClient struct {
 
 func (c *pluginClient) List(ctx context.Context, in *Request) ([]*drone.Registry, error) {
 	res := []*drone.Registry{}
-	err := c.client.Do(in, &res)
+	err := c.client.DoUsingContext(ctx, in, &res)
 	return res, err
 }

--- a/plugin/secret/client.go
+++ b/plugin/secret/client.go
@@ -36,6 +36,6 @@ type pluginClient struct {
 
 func (c *pluginClient) Find(ctx context.Context, in *Request) (*drone.Secret, error) {
 	res := new(drone.Secret)
-	err := c.client.Do(in, res)
+	err := c.client.DoUsingContext(ctx, in, res)
 	return res, err
 }

--- a/plugin/secret/client.go
+++ b/plugin/secret/client.go
@@ -36,6 +36,6 @@ type pluginClient struct {
 
 func (c *pluginClient) Find(ctx context.Context, in *Request) (*drone.Secret, error) {
 	res := new(drone.Secret)
-	err := c.client.DoUsingContext(ctx, in, res)
+	err := c.client.Do(ctx, in, res)
 	return res, err
 }

--- a/plugin/validator/client.go
+++ b/plugin/validator/client.go
@@ -34,5 +34,5 @@ type pluginClient struct {
 }
 
 func (c *pluginClient) Validate(ctx context.Context, in *Request) error {
-	return c.client.DoUsingContext(ctx, in, nil)
+	return c.client.Do(ctx, in, nil)
 }

--- a/plugin/validator/client.go
+++ b/plugin/validator/client.go
@@ -34,5 +34,5 @@ type pluginClient struct {
 }
 
 func (c *pluginClient) Validate(ctx context.Context, in *Request) error {
-	return c.client.Do(in, nil)
+	return c.client.DoUsingContext(ctx, in, nil)
 }

--- a/plugin/webhook/client.go
+++ b/plugin/webhook/client.go
@@ -34,5 +34,5 @@ type pluginClient struct {
 }
 
 func (c *pluginClient) Deliver(ctx context.Context, in *Request) error {
-	return c.client.Do(in, nil)
+	return c.client.DoUsingContext(ctx, in, nil)
 }

--- a/plugin/webhook/client.go
+++ b/plugin/webhook/client.go
@@ -34,5 +34,5 @@ type pluginClient struct {
 }
 
 func (c *pluginClient) Deliver(ctx context.Context, in *Request) error {
-	return c.client.DoUsingContext(ctx, in, nil)
+	return c.client.Do(ctx, in, nil)
 }


### PR DESCRIPTION
Plugin implementations pass a ctx when
invoking each plugin. This was previously
ignored.