### PR TITLE
Use http constants for status codes

### DIFF
--- a/plugin/admission/handler.go
+++ b/plugin/admission/handler.go
@@ -57,19 +57,19 @@ func (p *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	signature, err := httpsignatures.FromRequest(r)
 	if err != nil {
 		p.logger.Debugf("admission: invalid or missing signature in http.Request")
-		http.Error(w, "Invalid or Missing Signature", 400)
+		http.Error(w, "Invalid or Missing Signature", http.StatusBadRequest)
 		return
 	}
 	if !signature.IsValid(p.secret, r) {
 		p.logger.Debugf("admission: invalid signature in http.Request")
-		http.Error(w, "Invalid Signature", 400)
+		http.Error(w, "Invalid Signature", http.StatusBadRequest)
 		return
 	}
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		p.logger.Debugf("admission: cannot read http.Request body")
-		w.WriteHeader(400)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
@@ -77,7 +77,7 @@ func (p *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err = json.Unmarshal(body, req)
 	if err != nil {
 		p.logger.Debugf("admission: cannot unmarshal http.Request body")
-		http.Error(w, "Invalid Input", 400)
+		http.Error(w, "Invalid Input", http.StatusBadRequest)
 		return
 	}
 
@@ -87,11 +87,11 @@ func (p *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			req.User.Login,
 			err,
 		)
-		http.Error(w, err.Error(), 403)
+		http.Error(w, err.Error(), http.StatusForbidden)
 		return
 	}
 	if res == nil {
-		w.WriteHeader(204)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	out, _ := json.Marshal(res)

--- a/plugin/admission/handler_test.go
+++ b/plugin/admission/handler_test.go
@@ -93,7 +93,7 @@ func TestHandler_NoContent(t *testing.T) {
 	handler := Handler(plugin, key, nil)
 	handler.ServeHTTP(res, req)
 
-	if got, want := res.Code, 204; got != want {
+	if got, want := res.Code, http.StatusNoContent; got != want {
 		t.Errorf("Want status code %d, got %d", want, got)
 	}
 }

--- a/plugin/config/handler.go
+++ b/plugin/config/handler.go
@@ -57,19 +57,19 @@ func (p *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	signature, err := httpsignatures.FromRequest(r)
 	if err != nil {
 		p.logger.Debugf("config: invalid or missing signature in http.Request")
-		http.Error(w, "Invalid or Missing Signature", 400)
+		http.Error(w, "Invalid or Missing Signature", http.StatusBadRequest)
 		return
 	}
 	if !signature.IsValid(p.secret, r) {
 		p.logger.Debugf("config: invalid signature in http.Request")
-		http.Error(w, "Invalid Signature", 400)
+		http.Error(w, "Invalid Signature", http.StatusBadRequest)
 		return
 	}
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		p.logger.Debugf("config: cannot read http.Request body")
-		w.WriteHeader(400)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
@@ -77,7 +77,7 @@ func (p *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err = json.Unmarshal(body, req)
 	if err != nil {
 		p.logger.Debugf("config: cannot unmarshal http.Request body")
-		http.Error(w, "Invalid Input", 400)
+		http.Error(w, "Invalid Input", http.StatusBadRequest)
 		return
 	}
 
@@ -88,11 +88,11 @@ func (p *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			req.Build.Target,
 			err,
 		)
-		http.Error(w, err.Error(), 404)
+		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
 	if res == nil {
-		w.WriteHeader(204)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	out, _ := json.Marshal(res)

--- a/plugin/converter/handler.go
+++ b/plugin/converter/handler.go
@@ -58,19 +58,19 @@ func (p *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	signature, err := httpsignatures.FromRequest(r)
 	if err != nil {
 		p.logger.Debugf("converter: invalid or missing signature in http.Request")
-		http.Error(w, "Invalid or Missing Signature", 400)
+		http.Error(w, "Invalid or Missing Signature", http.StatusBadRequest)
 		return
 	}
 	if !signature.IsValid(p.secret, r) {
 		p.logger.Debugf("converter: invalid signature in http.Request")
-		http.Error(w, "Invalid Signature", 400)
+		http.Error(w, "Invalid Signature", http.StatusBadRequest)
 		return
 	}
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		p.logger.Debugf("converter: cannot read http.Request body")
-		w.WriteHeader(400)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
@@ -78,7 +78,7 @@ func (p *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err = json.Unmarshal(body, req)
 	if err != nil {
 		p.logger.Debugf("converter: cannot unmarshal http.Request body")
-		http.Error(w, "Invalid Input", 400)
+		http.Error(w, "Invalid Input", http.StatusBadRequest)
 		return
 	}
 
@@ -89,11 +89,11 @@ func (p *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			req.Build.Target,
 			err,
 		)
-		http.Error(w, err.Error(), 404)
+		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
 	if res == nil {
-		w.WriteHeader(204)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	out, _ := json.Marshal(res)

--- a/plugin/internal/client/client.go
+++ b/plugin/internal/client/client.go
@@ -148,7 +148,7 @@ func (s *Client) Do(ctx context.Context, in, out interface{}) error {
 	// if the response body return no content we exit
 	// immediately. We do not read or unmarshal the response
 	// and we do not return an error.
-	if res.StatusCode == 204 {
+	if res.StatusCode == http.StatusNoContent {
 		return nil
 	}
 

--- a/plugin/registry/handler.go
+++ b/plugin/registry/handler.go
@@ -58,19 +58,19 @@ func (p *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	signature, err := httpsignatures.FromRequest(r)
 	if err != nil {
 		p.logger.Debugf("registry: invalid or missing signature in http.Request")
-		http.Error(w, "Invalid or Missing Signature", 400)
+		http.Error(w, "Invalid or Missing Signature", http.StatusBadRequest)
 		return
 	}
 	if !signature.IsValid(p.secret, r) {
 		p.logger.Debugf("registry: invalid signature in http.Request")
-		http.Error(w, "Invalid Signature", 400)
+		http.Error(w, "Invalid Signature", http.StatusBadRequest)
 		return
 	}
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		p.logger.Debugf("registry: cannot read http.Request body")
-		w.WriteHeader(400)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
@@ -78,14 +78,14 @@ func (p *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err = json.Unmarshal(body, req)
 	if err != nil {
 		p.logger.Debugf("registry: cannot unmarshal http.Request body")
-		http.Error(w, "Invalid Input", 400)
+		http.Error(w, "Invalid Input", http.StatusBadRequest)
 		return
 	}
 
 	auths, err := p.plugin.List(r.Context(), req)
 	if err != nil {
 		p.logger.Debugf("registry: cannot list registries: %s", err)
-		http.Error(w, err.Error(), 404)
+		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
 	out, _ := json.Marshal(auths)
@@ -96,13 +96,13 @@ func (p *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		key, err := aesgcm.Key(p.secret)
 		if err != nil {
 			p.logger.Errorf("registry: invalid encryption key: %s", err)
-			http.Error(w, err.Error(), 500)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		out, err = aesgcm.Encrypt(out, key)
 		if err != nil {
 			p.logger.Errorf("registry: cannot encrypt message: %s", err)
-			http.Error(w, err.Error(), 500)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		w.Header().Set("Content-Encoding", "aesgcm")

--- a/plugin/secret/handler.go
+++ b/plugin/secret/handler.go
@@ -58,19 +58,19 @@ func (p *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	signature, err := httpsignatures.FromRequest(r)
 	if err != nil {
 		p.logger.Debugf("secrets: invalid or missing signature in http.Request")
-		http.Error(w, "Invalid or Missing Signature", 400)
+		http.Error(w, "Invalid or Missing Signature", http.StatusBadRequest)
 		return
 	}
 	if !signature.IsValid(p.secret, r) {
 		p.logger.Debugf("secrets: invalid signature in http.Request")
-		http.Error(w, "Invalid Signature", 400)
+		http.Error(w, "Invalid Signature", http.StatusBadRequest)
 		return
 	}
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		p.logger.Debugf("secrets: cannot read http.Request body")
-		w.WriteHeader(400)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
@@ -78,14 +78,14 @@ func (p *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err = json.Unmarshal(body, req)
 	if err != nil {
 		p.logger.Debugf("secrets: cannot unmarshal http.Request body")
-		http.Error(w, "Invalid Input", 400)
+		http.Error(w, "Invalid Input", http.StatusBadRequest)
 		return
 	}
 
 	secret, err := p.plugin.Find(r.Context(), req)
 	if err != nil {
 		p.logger.Debugf("secrets: cannot find secret %s: %s", req.Name, err)
-		http.Error(w, err.Error(), 404)
+		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
 	out, _ := json.Marshal(secret)
@@ -96,13 +96,13 @@ func (p *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		key, err := aesgcm.Key(p.secret)
 		if err != nil {
 			p.logger.Errorf("secrets: invalid encryption key: %s", err)
-			http.Error(w, err.Error(), 500)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		out, err = aesgcm.Encrypt(out, key)
 		if err != nil {
 			p.logger.Errorf("secrets: cannot encrypt message: %s", err)
-			http.Error(w, err.Error(), 500)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		w.Header().Set("Content-Encoding", "aesgcm")

--- a/plugin/validator/handler.go
+++ b/plugin/validator/handler.go
@@ -60,19 +60,19 @@ func (p *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	signature, err := httpsignatures.FromRequest(r)
 	if err != nil {
 		p.logger.Debugf("validator: invalid or missing signature in http.Request")
-		http.Error(w, "Invalid or Missing Signature", 400)
+		http.Error(w, "Invalid or Missing Signature", http.StatusBadRequest)
 		return
 	}
 	if !signature.IsValid(p.secret, r) {
 		p.logger.Debugf("validator: invalid signature in http.Request")
-		http.Error(w, "Invalid Signature", 400)
+		http.Error(w, "Invalid Signature", http.StatusBadRequest)
 		return
 	}
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		p.logger.Debugf("validator: cannot read http.Request body")
-		w.WriteHeader(400)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
@@ -80,7 +80,7 @@ func (p *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err = json.Unmarshal(body, req)
 	if err != nil {
 		p.logger.Debugf("validator: cannot unmarshal http.Request body")
-		http.Error(w, "Invalid Input", 400)
+		http.Error(w, "Invalid Input", http.StatusBadRequest)
 		return
 	}
 
@@ -110,6 +110,6 @@ func (p *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	out, _ := json.Marshal(err)
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	w.Write(out)
 }

--- a/plugin/webhook/handler.go
+++ b/plugin/webhook/handler.go
@@ -57,19 +57,19 @@ func (p *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	signature, err := httpsignatures.FromRequest(r)
 	if err != nil {
 		p.logger.Debugf("webhook: invalid or missing signature in http.Request")
-		http.Error(w, "Invalid or Missing Signature", 400)
+		http.Error(w, "Invalid or Missing Signature", http.StatusBadRequest)
 		return
 	}
 	if !signature.IsValid(p.secret, r) {
 		p.logger.Debugf("webhook: invalid signature in http.Request")
-		http.Error(w, "Invalid Signature", 400)
+		http.Error(w, "Invalid Signature", http.StatusBadRequest)
 		return
 	}
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		p.logger.Debugf("webhook: cannot read http.Request body")
-		w.WriteHeader(400)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
@@ -77,14 +77,14 @@ func (p *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err = json.Unmarshal(body, req)
 	if err != nil {
 		p.logger.Debugf("webhook: cannot unmarshal http.Request body")
-		http.Error(w, "Invalid Input", 400)
+		http.Error(w, "Invalid Input", http.StatusBadRequest)
 		return
 	}
 
 	err = p.plugin.Deliver(r.Context(), req)
 	if err != nil {
-		http.Error(w, err.Error(), 500)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 	} else {
-		w.WriteHeader(204)
+		w.WriteHeader(http.StatusNoContent)
 	}
 }


### PR DESCRIPTION
One of the linters was complaining about using integers for status codes. Making all the status codes explicit with the constants present in `http`.