### PR TITLE
Chore: Add go.dev badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # drone-go
 
+[![Go.dev](https://pkg.go.dev/badge/github.com/drone/drone-go)](https://pkg.go.dev/github.com/drone/drone-go?tab=doc)
+
 ```Go
 package main
 


### PR DESCRIPTION
Add [go.dev](https://pkg.go.dev/github.com/drone/drone-go) badge to README, for easy access to docs.