### PR TITLE
update create template api to access namespace as a param

### DIFF
--- a/drone/client.go
+++ b/drone/client.go
@@ -673,9 +673,9 @@ func (c *client) TemplateList(namespace string) ([]*Template, error) {
 }
 
 // TemplateCreate creates a template.
-func (c *client) TemplateCreate(in *Template) (*Template, error) {
+func (c *client) TemplateCreate(namespace string, in *Template) (*Template, error) {
 	out := new(Template)
-	uri := fmt.Sprintf(pathTemplates, c.addr)
+	uri := fmt.Sprintf(pathTemplateNamespace, c.addr, namespace)
 	err := c.post(uri, in, out)
 	return out, err
 }

--- a/drone/interface.go
+++ b/drone/interface.go
@@ -246,7 +246,7 @@ type Client interface {
 	TemplateList(namespace string) ([]*Template, error)
 
 	// TemplateCreate creates a template.
-	TemplateCreate(template *Template) (*Template, error)
+	TemplateCreate(namespace string, template *Template) (*Template, error)
 
 	// TemplateUpdate updates template data.
 	TemplateUpdate(namespace string, name string, template *Template) (*Template, error)

--- a/drone/types.go
+++ b/drone/types.go
@@ -203,8 +203,8 @@ type (
 	}
 
 	Template struct {
-		Name      string `json:"name,omitempty"`
-		Data      string `json:"data,omitempty"`
+		Name string `json:"name,omitempty"`
+		Data string `json:"data,omitempty"`
 	}
 
 	// Server represents a server node.

--- a/drone/types.go
+++ b/drone/types.go
@@ -203,7 +203,6 @@ type (
 	}
 
 	Template struct {
-		Namespace string `json:"namespace,omitempty"`
 		Name      string `json:"name,omitempty"`
 		Data      string `json:"data,omitempty"`
 	}


### PR DESCRIPTION
Identified as issue where namespace was getting passed in on the payload rather than a URL param. This caused an issue during the checkmembership check on drone server as it requires namespace to be set.