### PR TITLE
support for async call to repo sync using options pattern

### DIFF
--- a/drone/client.go
+++ b/drone/client.go
@@ -188,11 +188,29 @@ func (c *client) RepoList() ([]*Repo, error) {
 	return out, err
 }
 
+// RepoListSyncOption is a functional option for RepoListSync.
+type RepoListSyncOption func(*url.Values)
+
+// WithAsync adds async=true to the RepoListSync request,
+// causing the server to trigger a sync and return immediately.
+func WithAsync() RepoListSyncOption {
+	return func(v *url.Values) {
+		v.Set("async", "true")
+	}
+}
+
 // RepoListSync returns a list of all repositories to which
 // the user has explicit access in the host system.
-func (c *client) RepoListSync() ([]*Repo, error) {
+func (c *client) RepoListSync(opts ...RepoListSyncOption) ([]*Repo, error) {
 	var out []*Repo
 	uri := fmt.Sprintf(pathRepos, c.addr)
+	if len(opts) > 0 {
+		params := url.Values{}
+		for _, opt := range opts {
+			opt(&params)
+		}
+		uri = uri + "?" + params.Encode()
+	}
 	err := c.post(uri, nil, &out)
 	return out, err
 }

--- a/drone/interface.go
+++ b/drone/interface.go
@@ -64,7 +64,7 @@ type Client interface {
 
 	// RepoListSync returns a list of all repositories to which
 	// the user has explicit access in the host system.
-	RepoListSync() ([]*Repo, error)
+	RepoListSync(opts ...RepoListSyncOption) ([]*Repo, error)
 
 	// RepoListAll returns a list of all repositories in
 	// the database. This is only available to system admins.


### PR DESCRIPTION
## Summary

Adds support for triggering an asynchronous repository sync by introducing a functional options pattern on the existing `RepoListSync` method.

This is one of two proposed approaches to resolve #74, which has been open since 2024. See #XX for an alternative implementation that adds a dedicated `RepoListSyncAsync()` function instead.

## Changes

- Adds `RepoListSyncOption` functional option type
- Adds `WithRepoListSyncAsync()` option constructor, which appends `async=true` to the request URL
- Updates `RepoListSync` in both the `Client` interface and `client` implementation to accept `opts ...RepoListSyncOption`

## Usage

```go
// Existing behaviour — unchanged
repos, err := client.RepoListSync()

// New — trigger async sync
repos, err := client.RepoListSync(drone.WithRepoListSyncAsync())
```

## Notes

- This is **backwards compatible** — all existing callers of `RepoListSync()` continue to work without modification.
  - code that references an interface for this functionality may need minor code changes.

The functional options pattern also leaves room for future query parameters to be added without further signature changes.

## Alternatives

See #76 for an alternative that adds a dedicated `RepoListSyncAsync()` function instead. That approach keeps the `Client` interface flat and makes the async behaviour self-documenting via the function name, at the cost of a new method per option.

